### PR TITLE
Project 0308

### DIFF
--- a/students/johnn/project/dcli
+++ b/students/johnn/project/dcli
@@ -15,9 +15,10 @@ parser.add_option("-s", "--server", dest="server",
 parser.add_option("-g", "--get", dest="get", action="store_true", help="Send a data query the server")
 parser.add_option("-p", "--put", dest="put", action="store_true", help="Set the data value on the server")
 parser.add_option("-k", "--key", dest="key", help="key to process")
+parser.add_option("-r", "--raw", dest="raw", help="debug only - send raw string to server")
 parser.add_option("-v", "--value", dest="value", help="key to process")
 parser.add_option("-e", "--echo_test", dest="test", help="Send an echo test to the server")
-parser.add_option("-l", "--link", dest="link", action="store_true", help="Link this server to another")
+parser.add_option("-l", "--link", dest="link", help="Link this server to another")
 parser.add_option("-d", "--debug", dest="debug", action="store_true", help="Print debug information to the screen")
 parser.add_option("--dump", dest="dump", action="store_true", help="Show all values in the database")
 
@@ -83,7 +84,10 @@ if options.test:
     send_message(build_message("echo_test", "", options.value))
 
 if options.link:
-    send_message(build_message("link", "", options.value))
+    send_message(build_message("link", "", options.link))
 
 if options.dump:
     send_message(build_message("dump", "", ""))
+
+if options.raw:
+    send_message(options.raw)


### PR DESCRIPTION
This adds the basic groundwork to allow linkages between servers to work more fully.  Now when you initiate a link request, it contacts the admin port of the remote server and requests a dump of all of it's data.  This should provide the basis to sync state (data and subscriptions) at link time.

Link request sent to remote server 192.168.1.209, asking it to link with the server running at 192.168.1.34 (admin port):
```
johnn@johnn-lnx:~/uwpython/IntroPython-2017/students/johnn/project$ ./dcli -s "tcp://192.168.1.209:5561" --link "tcp://192.168.1.34:5561"
please enter a command
2018-03-08 23:23:28,921 INFO dcli 7770 sent ('link', '', 'tcp://192.168.1.34:5561') to tcp://192.168.1.209:5561
2018-03-08 23:23:28,924 INFO dcli 7770 received: initiating a link request to remote admin port at tcp://192.168.1.34:5561
johnn@johnn-lnx:~/uwpython/IntroPython-2017/students/johnn/project$
```

The server gets the request, then in turn opens a request to the admin port at the remote server, then sends it a dump command, then parses the dump results:
```
2018-03-08 23:23:28,900 INFO dcd:Thread-1 received command link, key , value tcp://192.168.1.34:5561
2018-03-08 23:23:28,900 DEBUG dcd:Thread-1 initiating a link request to remote admin port at tcp://192.168.1.34:5561
2018-03-08 23:23:28,901 DEBUG dcd:Thread-1 opening connection to tcp://192.168.1.34:5561
2018-03-08 23:23:28,901 DEBUG dcd:Thread-1 sending command ('dump', None, None)
2018-03-08 23:23:28,903 DEBUG dcd:Thread-1 got (('tcp://192.168.1.34:5561', 'tcp://192.168.1.34:5556'), {}, {})
2018-03-08 23:23:28,904 DEBUG dcd:Thread-1 remote_admin tcp://192.168.1.34:5561, remote_pub tcp://192.168.1.34:5556, data {}, peers {}
```
